### PR TITLE
Update to make it compatible with LTS releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.410</version>
+        <version>1.409</version>
     </parent>
 
     <artifactId>buildresult-trigger</artifactId>


### PR DESCRIPTION
Im running a LTS server and would like to use this plugin but I cant since its marked for 1.410. This simple pull requests only updates the parent version to 1.409. It would be great if you could merge it and release a new version.

Regards
//Erik
