### PR TITLE
impersonate to SYSTEM to lookup job by name from trigger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.410</version>
+        <version>1.461</version>
     </parent>
 
     <artifactId>buildresult-trigger</artifactId>


### PR DESCRIPTION
This fixes the permission.READ issue without hacking Jenkins.items, by escalating trigger permission as it lookup job by name.

1.461 required to get ACL.impersonate(), but this method handle concurrency issue changing SecurityContext
