### PR TITLE
Bumped Plugin pom to 2.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Build Result Trigger Plugin
+
+BuildResultTrigger makes it possible to monitor the build results of other jobs. 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.522</version>
+        <version>2.30</version>
     </parent>
 
     <artifactId>buildresult-trigger</artifactId>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,6 @@
-<div>
-    This plugin makes it possible to monitor the build results of other jobs.
-</div>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <div>
+        This plugin makes it possible to monitor the build results of other jobs.
+    </div>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry field="combinedJobs">

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTriggerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTriggerAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <l:layout>
         <st:include it="${it.owner}" page="sidepanel.jelly"/>

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry field="jobNames" title="${%Job to monitor}">
         <f:textbox autoCompleteDelimChar=","/>

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/CheckedResult/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/CheckedResult/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry field="result" title="${%Job Build Result}">


### PR DESCRIPTION
Simple plugin pom version bump required for [[JENKINS-27301] pipeline compatibility](https://issues.jenkins-ci.org/browse/JENKINS-27301). No new functionality.

- bumped plugin pom to 2.30 and fixed all compilation errors, FindBugs warnings, javadoc errors and added jelly escapes
- added README 