### PR TITLE
Allow monitoring pipeline builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.522</version>
+        <version>4.16</version>
+        <relativePath />
     </parent>
 
     <artifactId>buildresult-trigger</artifactId>
@@ -29,10 +30,13 @@
     </developers>
 
     <properties>
+        <jenkins.version>2.204.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <xtrigger.lib.version>0.28</xtrigger.lib.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <xtrigger.lib.version>0.34</xtrigger.lib.version>
+        <matrix.project.version>1.12</matrix.project.version>
+        <java.level>8</java.level>
     </properties>
 
     <scm>
@@ -45,6 +49,11 @@
             <groupId>org.jenkins-ci.lib</groupId>
             <artifactId>xtrigger-lib</artifactId>
             <version>${xtrigger.lib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>${matrix.project.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/buildresulttrigger/BuildResultTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/buildresulttrigger/BuildResultTrigger.java
@@ -177,7 +177,7 @@ public class BuildResultTrigger extends AbstractTriggerByFullContext<BuildResult
         try {
             for (BuildResultTriggerInfo info : jobsInfo) {
                 for (String jobName : info.getJobNamesAsArray()) {
-                    AbstractProject job = Jenkins.getInstance().getItem(jobName, this.job.getParent(), AbstractProject.class);
+                    Job job = Jenkins.getInstance().getItem(jobName, this.job.getParent(), Job.class);
 
                     if (isValidBuildResultProject(job)) {
                         Run lastBuild = job.getLastCompletedBuild();
@@ -198,7 +198,7 @@ public class BuildResultTrigger extends AbstractTriggerByFullContext<BuildResult
         return new BuildResultTriggerContext(contextResults);
     }
 
-    private boolean isValidBuildResultProject(AbstractProject item) {
+    private boolean isValidBuildResultProject(Job item) {
         return item != null && !(item instanceof MatrixConfiguration);
     }
 
@@ -305,7 +305,7 @@ public class BuildResultTrigger extends AbstractTriggerByFullContext<BuildResult
             return false;
         }
 
-        AbstractProject jobObj = Jenkins.getInstance().getItem(jobName, this.job.getParent(), AbstractProject.class);
+        Job jobObj = Jenkins.getInstance().getItem(jobName, this.job.getParent(), Job.class);
         Run jobObjLastBuild = jobObj.getBuildByNumber(buildId.intValue());
         Result jobObjectLastResult = jobObjLastBuild.getResult();
 

--- a/src/main/java/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.buildresulttrigger.model;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.*;
-import hudson.tasks.Messages;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo.java
@@ -133,8 +133,8 @@ public class BuildResultTriggerInfo extends AbstractDescribableImpl<BuildResultT
                         return FormValidation.error(Messages.BuildTrigger_NoSuchProject(projectName,
                                 AbstractProject.findNearest(projectName, project.getParent()).getRelativeNameFrom(project)));
                     }
-                    if (!(item instanceof AbstractProject)) {
-                        return FormValidation.error(Messages.BuildTrigger_NotBuildable(projectName));
+                    if (!(item instanceof Job)) {
+                        return FormValidation.error(Messages.BuildTrigger_NotBuildable(item.getClass().getName()));
                     }
                     hasProjects = true;
                 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     This plugin makes it possible to monitor the build results of other jobs.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry field="combinedJobs">

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTriggerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/BuildResultTriggerAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <l:layout>
         <st:include it="${it.owner}" page="sidepanel.jelly"/>

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/BuildResultTriggerInfo/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry field="jobNames" title="${%Job to monitor}">
         <f:textbox autoCompleteDelimChar=","/>

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/CheckedResult/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/CheckedResult/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry field="result" title="${%Job Build Result}">

--- a/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/buildresulttrigger/model/Messages.properties
@@ -1,0 +1,3 @@
+BuildTrigger.NoSuchProject= No such project {0}, did you mean {1}
+BuildTrigger.NotBuildable = Project {0} not buildable
+BuildTrigger.NoProjectSpecified = No project specified


### PR DESCRIPTION
Fixes plugin not being able to monitor pipeline builds ("job is not buildable" error)